### PR TITLE
リソースを読み込めない

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -32,7 +32,7 @@ jobs:
         sudo -E apt install -y -qq gridsite-clients
         for i in build/web/assets/workflow/*.yaml ; do
           n=$(urlencode -d $i)
-          [ "$n" != "$i" ] && mv -i $i $n
+          [ "$n" != "$i" ] && mv $i $n || true
         done
       env:
         DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -13,6 +13,8 @@ jobs:
       LC_ALL: ja_JP.utf8
 
     steps:
+    - name: setup locale
+      run: localedef -f UTF-8 -i ja_JP ja_JP
     - uses: actions/checkout@master
     - uses: subosito/flutter-action@v1
       with:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -28,9 +28,10 @@ jobs:
       run: flutter build web
     - name: fix urlencode
       run: |
+        set -x
         sudo -E apt install -y -qq gridsite-clients
         for i in build/web/assets/workflow/*.yaml ; do
-          n=$(urlencode -e $i)
+          n=$(urlencode -d $i)
           [ "$n" != "$i" ] && mv -i $i $n
         done
       env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2,7 +2,7 @@ name: build-web
 
 on:
   push:
-    branches: [master, escape-filename]
+    branches: [master]
 
 jobs:
   build-web:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -31,6 +31,13 @@ jobs:
     #  run: flutter test
     - name: build web
       run: flutter build web
+    - name: fix urlencode
+      run: |
+        apt install -y gridsite-clients
+        for i in build/web/assets/workflow/*.yaml ; do
+          n=$(urlencode -e $i)
+          [ "$n" != "$i" ] && mv -i $i $n
+        done
     - name: list resource
       run: ls -lR build/web
     #- name: disable jekyll

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       LANG: ja_JP.utf8
       LC_ALL: ja_JP.utf8
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
     - name: setup locale

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -33,7 +33,7 @@ jobs:
       run: flutter build web
     - name: fix urlencode
       run: |
-        apt install -y gridsite-clients
+        sudo apt install -y gridsite-clients
         for i in build/web/assets/workflow/*.yaml ; do
           n=$(urlencode -e $i)
           [ "$n" != "$i" ] && mv -i $i $n

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,6 +8,9 @@ jobs:
   build-web:
     name: flutter build and deploy website
     runs-on: ubuntu-latest
+    env:
+      LANG: ja_JP.utf8
+      LC_ALL: ja_JP.utf8
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2,7 +2,7 @@ name: build-web
 
 on:
   push:
-    branches: [master]
+    branches: [master, escape-filename]
 
 jobs:
   build-web:
@@ -26,11 +26,13 @@ jobs:
     #  run: flutter test
     - name: build web
       run: flutter build web
-    - name: disable jekyll
-      run: touch build/web/.nojekyll
-    - name: deploy gh-pages
-      uses: peaceiris/actions-gh-pages@v2
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./build/web
+    - name: list resource
+      run: ls -lR build/web
+    #- name: disable jekyll
+    #  run: touch build/web/.nojekyll
+    #- name: deploy gh-pages
+    #  uses: peaceiris/actions-gh-pages@v2
+    #  env:
+    #    ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+    #    PUBLISH_BRANCH: gh-pages
+    #    PUBLISH_DIR: ./build/web

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: setup locale
-      run: localedef -f UTF-8 -i ja_JP ja_JP
+      run: sudo localedef -f UTF-8 -i ja_JP ja_JP
     - uses: actions/checkout@master
     - uses: subosito/flutter-action@v1
       with:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,14 +8,8 @@ jobs:
   build-web:
     name: flutter build and deploy website
     runs-on: ubuntu-latest
-    env:
-      LANG: ja_JP.utf8
-      LC_ALL: ja_JP.utf8
-      DEBIAN_FRONTEND: noninteractive
 
     steps:
-    - name: setup locale
-      run: sudo localedef -f UTF-8 -i ja_JP ja_JP
     - uses: actions/checkout@master
     - uses: subosito/flutter-action@v1
       with:
@@ -34,18 +28,20 @@ jobs:
       run: flutter build web
     - name: fix urlencode
       run: |
-        sudo apt install -y gridsite-clients
+        sudo -E apt install -y -qq gridsite-clients
         for i in build/web/assets/workflow/*.yaml ; do
           n=$(urlencode -e $i)
           [ "$n" != "$i" ] && mv -i $i $n
         done
+      env:
+        DEBIAN_FRONTEND: noninteractive
     - name: list resource
       run: ls -lR build/web
-    #- name: disable jekyll
-    #  run: touch build/web/.nojekyll
-    #- name: deploy gh-pages
-    #  uses: peaceiris/actions-gh-pages@v2
-    #  env:
-    #    ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-    #    PUBLISH_BRANCH: gh-pages
-    #    PUBLISH_DIR: ./build/web
+    - name: disable jekyll
+      run: touch build/web/.nojekyll
+    - name: deploy gh-pages
+      uses: peaceiris/actions-gh-pages@v2
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./build/web


### PR DESCRIPTION
日本語を使ったファイル名の`.yaml`ファイルを読み込むことができない。問題のファイルはurlencodeされたファイル名に変更されていた。

- ubuntu-latestのflutterの問題？
  - OKだったやつ…Flutter (Channel dev, v1.13.0, on Linux, locale C.UTF-8)
  - NGだったやつ…Flutter (Channel dev, v1.13.3, on Linux, locale C.UTF-8)

ローカルの`Flutter (Channel dev, v1.13.5, on Mac OS X 10.15.2 19C57, locale ja-JP)`でビルドしてassetsディレクトリを見ても、urlencodeはされていない。

- `peaceiris/actions-gh-pages@v2`の問題？
  - OKとNGの間の期間ではv2の新リリースはなかった
  - OKだったやつ…`af96b4:cc90e8d53227472baa48e978a4816071`
  - NGだったやつ…`671ee6:e2cac15e89c04cf5a97a75b10d47a8a0`